### PR TITLE
Removed unnecessary logs from task

### DIFF
--- a/svc-task/thandle/thandle.go
+++ b/svc-task/thandle/thandle.go
@@ -92,7 +92,6 @@ func (ts *TasksRPC) OverWriteCompletedTaskUtil(userName string) error {
 		timeToLeaveString, _ := time.ParseDuration("24h")
 		timeToLeaveNano := timeToLeaveString.Nanoseconds()
 		taskID = (strings.Split(value, "::"))[2]
-		log.Printf(taskID)
 		if elapsedTimeNano > timeToLeaveNano {
 			err = ts.deleteCompletedTask(taskID)
 			if err != nil {


### PR DESCRIPTION
Removing task id from log as it doesn't add to any information and is unncessary